### PR TITLE
Increasing the memory

### DIFF
--- a/spring-cloud-dataflow-deployer-mesos/src/main/java/org/springframework/cloud/dataflow/module/deployer/marathon/MarathonProperties.java
+++ b/spring-cloud-dataflow-deployer-mesos/src/main/java/org/springframework/cloud/dataflow/module/deployer/marathon/MarathonProperties.java
@@ -41,7 +41,7 @@ public class MarathonProperties {
 	/**
 	 * How much memory to allocate per module, can be overridden at deployment time.
 	 */
-	private double memory = 128.0D;
+	private double memory = 1024.0D;
 
 	/**
 	 * How many CPUs to allocate per module, can be overridden at deployment time.


### PR DESCRIPTION
- this will allow the server to deploy to local as well as AWS DCOS using defaults
- can be adjusted per app or for the server via properties

Resolves #38
