### PR TITLE
Rename Mesos starter project to 'autoconfig'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,18 +9,18 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-dataflow-parent</artifactId>
-		<version>1.1.0.M2</version>
+		<version>1.1.0.RELEASE</version>
 		<relativePath />  <!-- lookup parent from repository -->
 	</parent>
 
 	<modules>
 		<module>spring-cloud-dataflow-server-mesos-docs</module>
 		<module>spring-cloud-dataflow-server-mesos</module>
-		<module>spring-cloud-starter-dataflow-server-mesos</module>
+		<module>spring-cloud-dataflow-server-mesos-autoconfig</module>
 	</modules>
 
 	<properties>
-		<spring-cloud-dataflow.version>1.1.0.M2</spring-cloud-dataflow.version>
+		<spring-cloud-dataflow.version>1.1.0.RELEASE</spring-cloud-dataflow.version>
 		<spring-cloud-deployer-mesos.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-deployer-mesos.version>
 	</properties>
 

--- a/spring-cloud-dataflow-server-mesos-autoconfig/pom.xml
+++ b/spring-cloud-dataflow-server-mesos-autoconfig/pom.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>spring-cloud-starter-dataflow-server-mesos</artifactId>
-	<url>http://projects.spring.io/spring-cloud/</url>
-	<organization>
-		<name>Pivotal Software, Inc.</name>
-		<url>http://www.spring.io</url>
-	</organization>
+	<artifactId>spring-cloud-dataflow-server-mesos-autoconfig</artifactId>
+	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>spring-cloud-dataflow-server-mesos-autoconfig</name>
+
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-dataflow-server-mesos-parent</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
 	</parent>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -22,4 +23,12 @@
 			<artifactId>spring-cloud-dataflow-server-core</artifactId>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/spring-cloud-dataflow-server-mesos-autoconfig/src/main/java/org/springframework/cloud/dataflow/autoconfigure/mesos/MesosDataFlowServerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-mesos-autoconfig/src/main/java/org/springframework/cloud/dataflow/autoconfigure/mesos/MesosDataFlowServerAutoConfiguration.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.server.mesos;
+package org.springframework.cloud.dataflow.autoconfigure.mesos;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/spring-cloud-dataflow-server-mesos-autoconfig/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-dataflow-server-mesos-autoconfig/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.springframework.cloud.dataflow.autoconfigure.mesos.MesosDataFlowServerAutoConfiguration

--- a/spring-cloud-dataflow-server-mesos/pom.xml
+++ b/spring-cloud-dataflow-server-mesos/pom.xml
@@ -15,7 +15,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-dataflow-server-mesos</artifactId>
+			<artifactId>spring-cloud-dataflow-server-mesos-autoconfig</artifactId>
 			<version>1.1.0.BUILD-SNAPSHOT</version>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-dataflow-server-mesos/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-dataflow-server-mesos/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.springframework.cloud.dataflow.server.mesos.MesosDataFlowServerAutoConfiguration

--- a/spring-cloud-dataflow-server-mesos/src/test/java/org/springframework/cloud/dataflow/server/mesos/ContextLoadsTests.java
+++ b/spring-cloud-dataflow-server-mesos/src/test/java/org/springframework/cloud/dataflow/server/mesos/ContextLoadsTests.java
@@ -15,18 +15,38 @@
  */
 package org.springframework.cloud.dataflow.server.mesos;
 
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.Map;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.deployer.resource.docker.DockerResourceLoader;
+import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoader;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = MesosDataFlowServer.class)
 public class ContextLoadsTests {
 
-    @Test
-    public void contextLoads() {
+	@Autowired
+	private ApplicationContext context;
 
-    }
+	@Test
+	public void contextLoads() throws Exception {
+		assertThat(context.containsBean("delegatingResourceLoader"), is(true));
+		DelegatingResourceLoader delegatingResourceLoader = context.getBean(DelegatingResourceLoader.class);
+		Map<String, ResourceLoader> loaders = TestUtils.readField("loaders", delegatingResourceLoader);
+		assertThat(loaders.get("docker"), notNullValue());
+		ResourceLoader resourceLoader = loaders.get("docker");
+		assertThat(resourceLoader, instanceOf(DockerResourceLoader.class));
+	}
 
 }

--- a/spring-cloud-dataflow-server-mesos/src/test/java/org/springframework/cloud/dataflow/server/mesos/TestUtils.java
+++ b/spring-cloud-dataflow-server-mesos/src/test/java/org/springframework/cloud/dataflow/server/mesos/TestUtils.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.mesos;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Utils for tests.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class TestUtils {
+
+	@SuppressWarnings("unchecked")
+	public static <T> T readField(String name, Object target) throws Exception {
+		Field field = null;
+		Class<?> clazz = target.getClass();
+		do {
+			try {
+				field = clazz.getDeclaredField(name);
+			} catch (Exception ex) {
+			}
+
+			clazz = clazz.getSuperclass();
+		} while (field == null && !clazz.equals(Object.class));
+
+		if (field == null)
+			throw new IllegalArgumentException("Cannot find field '" + name + "' in the class hierarchy of "
+					+ target.getClass());
+		field.setAccessible(true);
+		return (T) field.get(target);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T callMethod(String name, Object target) throws Exception {
+		Class<?> clazz = target.getClass();
+		Method method = ReflectionUtils.findMethod(clazz, name);
+
+		if (method == null)
+			throw new IllegalArgumentException("Cannot find method '" + method + "' in the class hierarchy of "
+					+ target.getClass());
+		method.setAccessible(true);
+		return (T) ReflectionUtils.invokeMethod(method, target);
+	}
+
+	public static void setField(String name, Object target, Object value) throws Exception {
+		Field field = null;
+		Class<?> clazz = target.getClass();
+		do {
+			try {
+				field = clazz.getDeclaredField(name);
+			} catch (Exception ex) {
+			}
+
+			clazz = clazz.getSuperclass();
+		} while (field == null && !clazz.equals(Object.class));
+
+		if (field == null)
+			throw new IllegalArgumentException("Cannot find field '" + name + "' in the class hierarchy of "
+					+ target.getClass());
+		field.setAccessible(true);
+		field.set(target, value);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T callMethod(String name, Object target, Object[] args, Class<?>[] argsTypes) throws Exception {
+		Class<?> clazz = target.getClass();
+		Method method = ReflectionUtils.findMethod(clazz, name, argsTypes);
+
+		if (method == null)
+			throw new IllegalArgumentException("Cannot find method '" + method + "' in the class hierarchy of "
+					+ target.getClass());
+		method.setAccessible(true);
+		return (T) ReflectionUtils.invokeMethod(method, target, args);
+	}
+
+}


### PR DESCRIPTION
- Move MesosDataFlowServerAutoConfiguration into its
  own auto-config jar.
- Add testing that auto-config adds resource
  loader for docker.
- Remove old starter
- Upgrade to SCDF 1.1.0.RELEASE for shell to work.
- Fixes #96